### PR TITLE
Kylepena/fix noncompiled bblessed

### DIFF
--- a/lib/tput.js
+++ b/lib/tput.js
@@ -4,10 +4,10 @@
  * https://github.com/chjj/blessed
  */
 
-import xtermFile from "../usr/xterm" with {
+/*import xtermFile from "../usr/xterm" with {
   type: "file",
   embed: "true"
-}
+}*/
 
 // Resources:
 //   $ man term
@@ -134,8 +134,8 @@ Tput.prototype._useXtermCap = function() {
 
 Tput.prototype._useXtermInfo = function() {
   log(`Using xterm terminfo: ${__dirname + '/../usr/xterm'}`)
-  // return this.injectTerminfo(__dirname + '/../usr/xterm');
-  return this.injectTerminfo(xtermFile);
+  return this.injectTerminfo(__dirname + '/../usr/xterm');
+  //return this.injectTerminfo(xtermFile);
 };
 
 Tput.prototype._useInternalInfo = function(name) {
@@ -3091,6 +3091,10 @@ Tput.utoa = Tput.prototype.utoa = {
  * Expose
  */
 
+/*
+export default Tput;
+export { sprintf, tryRead };
+*/
 exports = Tput;
 exports.sprintf = sprintf;
 exports.tryRead = tryRead;

--- a/lib/tput.js
+++ b/lib/tput.js
@@ -4,11 +4,6 @@
  * https://github.com/chjj/blessed
  */
 
-/*import xtermFile from "../usr/xterm" with {
-  type: "file",
-  embed: "true"
-}*/
-
 // Resources:
 //   $ man term
 //   $ man terminfo
@@ -135,7 +130,6 @@ Tput.prototype._useXtermCap = function() {
 Tput.prototype._useXtermInfo = function() {
   log(`Using xterm terminfo: ${__dirname + '/../usr/xterm'}`)
   return this.injectTerminfo(__dirname + '/../usr/xterm');
-  //return this.injectTerminfo(xtermFile);
 };
 
 Tput.prototype._useInternalInfo = function(name) {
@@ -3091,10 +3085,6 @@ Tput.utoa = Tput.prototype.utoa = {
  * Expose
  */
 
-/*
-export default Tput;
-export { sprintf, tryRead };
-*/
 exports = Tput;
 exports.sprintf = sprintf;
 exports.tryRead = tryRead;


### PR DESCRIPTION
**The problem:**
It was impossible to run our fork of bblessed in bun without first compiling it.

**Why**
There are two styles of modules - ESM and CommonJS.  While Bun lets you mix these paradigms to a certain extent, it also uses heuristics to determine if a file is "CommonJS only".  If a file is "CommonJS only", it can't use ESM-style import statements.

In `lib/tput.js`, bun believes it is a "CommonJS" only file because of the way that it declares its exports.  Yet, this file has an ESM style import (actually, an "attribute import" of a file, which Bun uses to signal which files to embed in a single-file executable).  So, Bun is actually unable to execute this file because it is using a forbidden ESM-style import.

However - our fork *does* work when it is compiled first.  Why?  My best guess is that the compiler transpiles away the differences between CommonJS and ESM, and the fact that this file is "mixed" in this way ends up not mattering after transpilation.  We have only been running our workers after compiling (read: transpiling) them, which is why we haven't encountered this problem before.

**The Solve**

In any case, if we remove the ESM-style attribute import, the file becomes truly CommonJS compatible, and as a result we can run it without compiling it first.  I know this for a fact because I tested it.

However - now we aren't signaling to Bun that we want to embed a certain file within the single-file executable.  That would be a problem for our **compiled** workers.  However, I did notice in our bunfig.toml that we are explicitly including these files via a `[build.include]` attribute.  Assuming this attribute isn't bogus, we should be good.  I tested the compiled worker, and as long as i'm not deceiving myself, the compiled workers still seem to be working.  Would appreciate comment on this if I am misunderstanding.